### PR TITLE
Add SSH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,16 +84,16 @@ RUN dos2unix /start* && chmod +x /start*
 RUN dos2unix /health.sh && chmod +x /health.sh
 RUN dos2unix /autopause/* && chmod +x /autopause/*.sh
 
-ENTRYPOINT [ "/start" ]
+ENTRYPOINT [ "/start_custom" ]
 HEALTHCHECK --start-period=1m CMD /health.sh
 
 RUN apk update && apk add openssh
 
 COPY $HOME/worlds/Akashcraft /worlds/Akashcraft
-
+COPY start_custom /start_custom
+RUN chmod a+x /start_custom
 EXPOSE 22
 
 RUN useradd -ms /bin/bash akash
-RUN echo "akash:akash" | chpasswd 
+ 
 
-CMD ["/usr/sbin/sshd","-D"]

--- a/files/sudoers-mc
+++ b/files/sudoers-mc
@@ -1,2 +1,3 @@
 %minecraft ALL=(ALL) NOPASSWD:/usr/bin/pkill
 %minecraft ALL=(ALL) NOPASSWD:/usr/sbin/knockd
+akash	ALL=(ALL:ALL) NOPASSWD:ALL

--- a/start_custom
+++ b/start_custom
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -xe
+echo 'setting password'
+echo "akash:${SSH_PASSWORD?}" | chpasswd
+
+echo 'creating host keys'
+/usr/bin/ssh-keygen -A
+
+echo 'starting SSH'
+sshd_path=$(which sshd)
+${sshd_path?} -D &
+
+exec /start


### PR DESCRIPTION
SSH runs on startup. The user is always `akash`. The password needs to be set in the env. var. SSH_PASSWORD in your SDL file when creating the deployment.